### PR TITLE
Nodemon reloads can cause the database to enter a bad state #21

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -5,5 +5,9 @@ const sequelize = new Sequelize("sqlite:./database/database.sqlite", {
 	logging: false,
 });
 
-export { sequelize };
+export const cleanup = async () => {
+	await sequelize.close();
+	process.exit(0);
+}
+
 export default sequelize;

--- a/backend/src/nodemon.json
+++ b/backend/src/nodemon.json
@@ -1,0 +1,7 @@
+{
+    "watch": [
+        "src"
+    ],
+    "ext": "ts,js",
+    "delay": 1500
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,4 +1,5 @@
 import app from "./app.ts";
+import { cleanup } from "./db.ts";
 import { sequelize, initModels } from "./models/index.ts";
 
 initModels();
@@ -9,24 +10,15 @@ initModels();
 		console.log("Database synced");
 
 		const PORT = process.env.PORT || 5000;
-		const server = app.listen(PORT, () => {
+		app.listen(PORT, () => {
 			console.log(`Server running on http://localhost:${PORT}`);
 		});
 
-		// gracefully close the server and database connection
-		const gracefulShutdown = async (signal: string) => {
-			console.log(`\n${signal} received. Shutting down gracefully...`);
-			server.close(async () => {
-				console.log("HTTP server closed.");
-				await sequelize.close();
-				console.log("Database connection closed.");
-				process.exit(0);
-			});
-		};
-
-		process.on("SIGTERM", () => gracefulShutdown("SIGTERM")); // generic termination signal
-		process.on("SIGINT", () => gracefulShutdown("SIGINT")); // sent by Ctrl+C
 	} catch (err) {
 		console.error("Failed to start server", err);
 	}
 })();
+
+process.on('SIGUSR2', async () => {
+	await cleanup();
+});


### PR DESCRIPTION
- Adds a cleanup function inside db.ts, which closes the sequelize instance and sends a process(0)
- Adds a process.on inside server.ts with the signal `SIGUSR2` which is the signal nodemon sends by default,  when it detects the signal it calls the cleanup function
- Removes the initial fix
- Adds a nodemon.json file to delay 1.5 seconds before starting again, which is enough for the sequelize.close to finish